### PR TITLE
Fix SNAP and WIC screening thresholds

### DIFF
--- a/src/rules/program_rules/S2R007.py
+++ b/src/rules/program_rules/S2R007.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from src.rules.base_rule import BaseRule
 from src.rules.registry import register_rule
-from src.models.enums import IncomeType, HouseholdMemberType
+from src.models.enums import IncomeType
 
 
 @register_rule
@@ -14,157 +14,105 @@ class SupplementalNutritionAssistanceProgram(BaseRule):
     program = "S2R007"
     description = "Supplemental Nutrition Assistance Program (SNAP/Food Stamps) (HRA) - Food assistance program"
 
+    SPECIAL_CIRCUMSTANCE_LIMITS = {
+        1: 2608,
+        2: 3525,
+        3: 4442,
+        4: 5358,
+        5: 6275,
+        6: 7192,
+        7: 8108,
+        8: 9025,
+    }
+    EARNED_INCOME_LIMITS = {
+        1: 1957,
+        2: 2644,
+        3: 3332,
+        4: 4019,
+        5: 4707,
+        6: 5394,
+        7: 6082,
+        8: 6769,
+    }
+    OTHER_INCOME_LIMITS = {
+        1: 1696,
+        2: 2292,
+        3: 2888,
+        4: 3483,
+        5: 4079,
+        6: 4675,
+        7: 5271,
+        8: 5867,
+    }
+
     @classmethod
     def evaluate(cls, request) -> bool:
         """
-        SNAP eligibility has multiple pathways:
+        SNAP eligibility follows the public ACCESS NYC Drools gross-income screen:
         1. All household members receive SSI or Cash Assistance (categorical eligibility)
-        2. Income under 200% FPL with special circumstances (elderly/disabled/child care expenses)
-        3. Income under 150% FPL with earned income
-        4. Income under 130% FPL for all others
+        2. 200% gross income with child/dependent care, elderly, disabled, or blind
+        3. 150% gross income with earned income
+        4. 130% gross income for all others
         """
-        household = request.household[0]
         persons = request.person
-        household_size = len(persons) + request.members_pregnant
-        
-        # Check categorical eligibility (all members have SSI or Cash Assistance)
+        household_size = len(persons)
+
         if cls._check_categorical_eligibility(request, persons):
             return True
-        
-        # Calculate SNAP budget
-        snap_income = cls._calculate_snap_income(request)
-        
-        # Determine which FPL threshold applies
-        fpl_multiplier = cls._determine_fpl_multiplier(request, persons)
-        
-        # Get FPL limit for household size
-        fpl_limit = cls._get_fpl_limit(household_size, fpl_multiplier)
-        
-        # Compare income to limit
-        return snap_income <= fpl_limit
-    
+
+        gross_income = cls._gross_income_minus_child_support(request)
+        limits = cls._income_limits_for_household(request, persons)
+        return gross_income <= limits.get(household_size, float("-inf"))
+
     @classmethod
     def _check_categorical_eligibility(cls, request, persons) -> bool:
         """Check if all household members have SSI or Cash Assistance"""
         if len(persons) == 0:
             return False
-            
+
         # Check if all persons have either SSI or Cash Assistance
         all_have_benefits = True
         for person in persons:
             has_ssi = False
             has_cash_assistance = False
-            
+
             for income in person.incomes:
                 if income.type == IncomeType.SSI:
                     has_ssi = True
                 elif income.type == IncomeType.CASH_ASSISTANCE:
                     has_cash_assistance = True
-            
+
             if not (has_ssi or has_cash_assistance):
                 all_have_benefits = False
                 break
-        
+
         return all_have_benefits
-    
+
     @classmethod
-    def _calculate_snap_income(cls, request) -> float:
-        """Calculate SNAP net income after all deductions"""
-        # Start with gross income
-        gross_income = (request.income_household_wage_self_employment_monthly + 
-                       request.income_household_boarder_monthly +
-                       request.income_household_unearned_monthly -
-                       request.expense_household_child_support_monthly)
-        
-        # Calculate deductions
-        deductions = 0.0
-        
-        # 20% earned income deduction
-        earned_income = (request.income_household_wage_self_employment_monthly + 
-                        request.income_household_boarder_monthly)
-        deductions += earned_income * 0.20
-        
-        # Standard deduction based on household size
-        household_size = len(request.person) + request.members_pregnant
-        if household_size <= 3:
-            deductions += 198
-        elif household_size == 4:
-            deductions += 208
-        elif household_size == 5:
-            deductions += 244
-        else:
-            deductions += 279
-        
-        # Homeless deduction if applicable
-        household = request.household[0]
-        if household.living_shelter:
-            deductions += 179.66
-        
-        # Dependent care expenses
-        deductions += request.expense_household_child_dependent_care_monthly
-        
-        # Medical expenses (only amount over $35 counts)
-        if request.expense_household_medical_monthly > 35:
-            deductions += request.expense_household_medical_monthly - 35
-        
-        # Calculate adjusted income
-        adjusted_income = gross_income - deductions
-        if adjusted_income < 0:
-            adjusted_income = 0
-        
-        # Calculate excess shelter costs
-        shelter_costs = request.expense_household_rent_mortgage_monthly + 992  # $992 utility allowance
-        excess_shelter = shelter_costs - (adjusted_income / 2)
-        if excess_shelter < 0:
-            excess_shelter = 0
-        
-        # Final SNAP net income
-        net_income = adjusted_income - excess_shelter
-        if net_income < 0:
-            net_income = 0
-        
-        return net_income
-    
+    def _gross_income_minus_child_support(cls, request) -> float:
+        gross_income = (
+            request.income_household_wage_self_employment_monthly
+            + request.income_household_boarder_monthly
+            + request.income_household_unearned_monthly
+            - request.expense_household_child_support_monthly
+        )
+        return max(gross_income, 0.0)
+
     @classmethod
-    def _determine_fpl_multiplier(cls, request, persons) -> float:
-        """Determine which FPL multiplier applies based on household circumstances"""
-        # Check for 200% FPL conditions
+    def _income_limits_for_household(cls, request, persons) -> dict[int, int]:
         has_child_care_expenses = request.expense_household_has_child_or_dependent_care
         has_elderly = any(p.age >= 60 for p in persons)
         has_disabled_or_blind = any(p.disabled or p.blind for p in persons)
-        
+
         if has_child_care_expenses or has_elderly or has_disabled_or_blind:
-            return 2.0
-        
-        # Check for 150% FPL condition (has earned income)
-        has_earned_income = (request.income_household_wage_self_employment_monthly > 0 or
-                           request.income_household_boarder_monthly > 0)
-        
+            return cls.SPECIAL_CIRCUMSTANCE_LIMITS
+
+        has_earned_income = (
+            request.income_household_wage_self_employment_monthly > 0
+            or request.income_household_boarder_monthly > 0
+        )
+
         if has_earned_income:
-            return 1.5
-        
-        # Default to 130% FPL
-        return 1.3
-    
-    @classmethod
-    def _get_fpl_limit(cls, household_size: int, multiplier: float) -> float:
-        """Get the FPL limit for given household size and multiplier"""
-        # 2024 FPL monthly amounts (approximate)
-        base_fpl = {
-            1: 1255,
-            2: 1704,
-            3: 2152,
-            4: 2600,
-            5: 3049,
-            6: 3497,
-            7: 3945,
-            8: 4394
-        }
-        
-        # For households larger than 8, add $449 per additional person
-        if household_size > 8:
-            limit = base_fpl[8] + (household_size - 8) * 449
-        else:
-            limit = base_fpl.get(household_size, base_fpl[1])
-        
-        return limit * multiplier
+            return cls.EARNED_INCOME_LIMITS
+
+        return cls.OTHER_INCOME_LIMITS

--- a/src/rules/program_rules/S2R022.py
+++ b/src/rules/program_rules/S2R022.py
@@ -13,41 +13,50 @@ class WomenInfantsChildren(BaseRule):
     program = "S2R022"
     description = "Women, Infants and Children (WIC) (NYS DOH) - Nutrition assistance for pregnant women and young children"
 
+    INCOME_THRESHOLDS = {
+        1: 28953,
+        2: 39128,
+        3: 49303,
+        4: 59478,
+        5: 69653,
+        6: 79828,
+        7: 90003,
+        8: 100178,
+    }
+
     @classmethod
     def evaluate(cls, request) -> bool:
         """
         Eligibility requires:
         1. NYC residence (assumed for all requests)
         2. At least one person who is pregnant or under age 5
-        3. Household income below thresholds based on household size
+        3. Household income below thresholds based on household size, or reported
+           Medicaid, Disability Medicaid, or Cash Assistance
         """
         persons = request.person
         household_size = len(persons)
-        
+
         # Check for pregnant person or child under 5
         has_eligible_person = any(
             p.pregnant or p.age < 5
             for p in persons
         )
-        
+
         if not has_eligible_person:
             return False
-        
-        # Income thresholds by household size
-        income_thresholds = {
-            1: 27861,
-            2: 37814,
-            3: 47767,
-            4: 57720,
-            5: 67673,
-            6: 77626,
-            7: 87579,
-            8: 97532
-        }
-        
-        # Check income eligibility
-        if household_size in income_thresholds:
-            if request.income_household_total_yearly <= income_thresholds[household_size]:
-                return True
-        
-        return False
+
+        if cls._has_categorical_benefit(request, persons):
+            return True
+
+        threshold = cls.INCOME_THRESHOLDS.get(household_size)
+        return threshold is not None and request.income_household_total_yearly <= threshold
+
+    @classmethod
+    def _has_categorical_benefit(cls, request, persons) -> bool:
+        return (
+            any(
+                p.benefits_medicaid or p.benefits_medicaid_disability
+                for p in persons
+            )
+            or request.income_household_has_cash_assistance
+        )

--- a/tests/unit/rules/snap_wic_rule_test.py
+++ b/tests/unit/rules/snap_wic_rule_test.py
@@ -1,0 +1,240 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from src.models.schemas import AggregateEligibilityRequest
+from src.rules.program_rules.S2R007 import SupplementalNutritionAssistanceProgram
+from src.rules.program_rules.S2R022 import WomenInfantsChildren
+from src.validation.validate_request import validate_request
+
+
+@pytest.mark.parametrize(
+    "payload_path",
+    sorted(Path("tests/data/payloads/S2R007_SNAP").glob("*/*.json")),
+)
+def test_snap_generated_fixture_corpus(payload_path):
+    expected = payload_path.parent.name == "true"
+    request = _aggregate_request_from_payload_path(payload_path)
+
+    assert SupplementalNutritionAssistanceProgram.evaluate(request) is expected
+
+
+@pytest.mark.parametrize(
+    "payload_path",
+    sorted(Path("tests/data/payloads/S2R022_WIC").glob("*/*.json")),
+)
+def test_wic_generated_fixture_corpus(payload_path):
+    expected = payload_path.parent.name == "true"
+    request = _aggregate_request_from_payload_path(payload_path)
+
+    assert WomenInfantsChildren.evaluate(request) is expected
+
+
+@pytest.mark.parametrize(
+    ("monthly_income", "expected"),
+    [
+        (1957, True),
+        (1958, False),
+    ],
+)
+def test_snap_earned_income_uses_public_drools_gross_threshold(
+    monthly_income, expected
+):
+    request = _aggregate_request(
+        [
+            _person(
+                age=30,
+                incomes=[
+                    {
+                        "amount": monthly_income,
+                        "type": "Wages",
+                        "frequency": "Monthly",
+                    }
+                ],
+            )
+        ]
+    )
+
+    assert SupplementalNutritionAssistanceProgram.evaluate(request) is expected
+
+
+@pytest.mark.parametrize(
+    ("monthly_income", "expected"),
+    [
+        (2608, True),
+        (2609, False),
+    ],
+)
+def test_snap_elderly_household_uses_public_drools_gross_threshold(
+    monthly_income, expected
+):
+    request = _aggregate_request(
+        [
+            _person(
+                age=60,
+                incomes=[
+                    {
+                        "amount": monthly_income,
+                        "type": "SSRetirement",
+                        "frequency": "Monthly",
+                    }
+                ],
+            )
+        ]
+    )
+
+    assert SupplementalNutritionAssistanceProgram.evaluate(request) is expected
+
+
+@pytest.mark.parametrize(
+    ("monthly_income", "expected"),
+    [
+        (1696, True),
+        (1697, False),
+    ],
+)
+def test_snap_unearned_income_uses_public_drools_gross_threshold(
+    monthly_income, expected
+):
+    request = _aggregate_request(
+        [
+            _person(
+                age=30,
+                incomes=[
+                    {
+                        "amount": monthly_income,
+                        "type": "SSRetirement",
+                        "frequency": "Monthly",
+                    }
+                ],
+            )
+        ]
+    )
+
+    assert SupplementalNutritionAssistanceProgram.evaluate(request) is expected
+
+
+@pytest.mark.parametrize(
+    ("income", "expected"),
+    [
+        (28_953, True),
+        (28_954, False),
+    ],
+)
+def test_wic_single_pregnant_adult_uses_public_drools_threshold(
+    income, expected
+):
+    request = _aggregate_request([_person(age=30, income=income, pregnant=True)])
+
+    assert WomenInfantsChildren.evaluate(request) is expected
+
+
+@pytest.mark.parametrize(
+    ("income", "expected"),
+    [
+        (39_128, True),
+        (39_129, False),
+    ],
+)
+def test_wic_two_person_child_household_uses_public_drools_threshold(
+    income, expected
+):
+    request = _aggregate_request(
+        [
+            _person(age=30, income=income),
+            _person(age=4, household_member_type="Child"),
+        ]
+    )
+
+    assert WomenInfantsChildren.evaluate(request) is expected
+
+
+def test_wic_for_child_household_reporting_medicaid():
+    request = _aggregate_request(
+        [
+            _person(age=30, income=100_000),
+            _person(age=4, household_member_type="Child", benefitsMedicaid=True),
+        ]
+    )
+
+    assert WomenInfantsChildren.evaluate(request)
+
+
+def test_wic_for_child_household_with_cash_assistance_income():
+    request = _aggregate_request(
+        [
+            _person(
+                age=30,
+                incomes=[
+                    {
+                        "amount": 100_000,
+                        "type": "CashAssistance",
+                        "frequency": "Yearly",
+                    }
+                ],
+            ),
+            _person(age=4, household_member_type="Child"),
+        ]
+    )
+
+    assert WomenInfantsChildren.evaluate(request)
+
+
+def _aggregate_request(persons):
+    payload = {
+        "household": [
+            {
+                "cashOnHand": 0.0,
+                "livingRentalType": "MarketRate",
+                "livingRenting": True,
+                "livingOwner": False,
+                "livingStayingWithFriend": False,
+                "livingHotel": False,
+                "livingShelter": False,
+                "livingPreferNotToSay": False,
+            }
+        ],
+        "person": persons,
+        "withholdPayload": False,
+    }
+
+    is_valid, eligibility_request, errors = validate_request(payload)
+    assert is_valid, errors
+    return AggregateEligibilityRequest.from_eligibility_request(eligibility_request)
+
+
+def _aggregate_request_from_payload_path(payload_path):
+    with payload_path.open() as f:
+        payload = json.load(f)
+
+    is_valid, eligibility_request, errors = validate_request(payload)
+    assert is_valid, errors
+    return AggregateEligibilityRequest.from_eligibility_request(eligibility_request)
+
+
+def _person(age, income=0, household_member_type="HeadOfHousehold", **overrides):
+    person = {
+        "age": age,
+        "householdMemberType": household_member_type,
+        "student": False,
+        "pregnant": False,
+        "studentFulltime": False,
+        "blind": False,
+        "disabled": False,
+        "veteran": False,
+        "unemployed": False,
+        "unemployedWorkedLast18Months": False,
+        "benefitsMedicaid": False,
+        "benefitsMedicaidDisability": False,
+        "livingOwnerOnDeed": False,
+        "livingRentalOnLease": household_member_type == "HeadOfHousehold",
+        "incomes": [],
+        "expenses": [],
+    }
+    if income:
+        person["incomes"].append(
+            {"amount": income, "type": "Wages", "frequency": "Yearly"}
+        )
+    person.update(overrides)
+    return person


### PR DESCRIPTION
## Summary

Fixes two ACCESS NYC Python screening rules to match the public Drools encodings more closely:

- `S2R007` SNAP now uses the public Drools gross monthly income screens instead of a net SNAP budget calculation.
- `S2R022` WIC now uses the current public Drools income table and includes the Medicaid, Disability Medicaid, and Cash Assistance categorical path.
- Adds focused unit tests for SNAP gross-income threshold boundaries and WIC income/categorical boundaries.

## Notes

This PR is based on the `tests` branch from #6 so it can be reviewed independently of #7.

## Validation

- `UV_FROZEN=0 uv run pytest tests/unit/rules/snap_wic_rule_test.py -q`
- `UV_FROZEN=0 uv run pytest -q`
- `UV_FROZEN=0 uv run python -m compileall -q src tests`
- `git diff --check`


Fixes #9
